### PR TITLE
Ensure that highest sigma bot is in each game

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -157,6 +157,10 @@ class Manager:
         open_set = [i for i in range(0, len(self.players))]
         players = []
         count = 0
+	high_sigma = sorted(self.players, key=lambda x: x.sigma, reverse=True)[0]
+        high_sigma_i = self.players.index(high_sigma)
+        players.append(high_sigma_i)
+        open_set.remove(high_sigma_i)
         while count < num:
             chosen = open_set[random.randint(0, len(open_set) - 1)]
             players.append(chosen)

--- a/manager.py
+++ b/manager.py
@@ -156,11 +156,11 @@ class Manager:
     def pick_players(self, num):
         open_set = [i for i in range(0, len(self.players))]
         players = []
-        count = 0
         high_sigma = sorted(self.players, key=lambda x: x.sigma, reverse=True)[0]
         high_sigma_i = self.players.index(high_sigma)
         players.append(high_sigma_i)
         open_set.remove(high_sigma_i)
+	count = 1
         while count < num:
             chosen = open_set[random.randint(0, len(open_set) - 1)]
             players.append(chosen)

--- a/manager.py
+++ b/manager.py
@@ -157,7 +157,7 @@ class Manager:
         open_set = [i for i in range(0, len(self.players))]
         players = []
         count = 0
-	high_sigma = sorted(self.players, key=lambda x: x.sigma, reverse=True)[0]
+        high_sigma = sorted(self.players, key=lambda x: x.sigma, reverse=True)[0]
         high_sigma_i = self.players.index(high_sigma)
         players.append(high_sigma_i)
         open_set.remove(high_sigma_i)

--- a/manager.py
+++ b/manager.py
@@ -160,7 +160,7 @@ class Manager:
         high_sigma_i = self.players.index(high_sigma)
         players.append(high_sigma_i)
         open_set.remove(high_sigma_i)
-	count = 1
+        count = 1
         while count < num:
             chosen = open_set[random.randint(0, len(open_set) - 1)]
             players.append(chosen)


### PR DESCRIPTION
Since the usual use case for this manager is comparing the relative rank of your library of bots, it makes sense to make sure that the most unknown bot is always playing, thus getting it a real ranking as soon as possible.